### PR TITLE
Fix: Enable Socket.send() to write more than 16Kb

### DIFF
--- a/Sources/TLS/Socket.swift
+++ b/Sources/TLS/Socket.swift
@@ -116,12 +116,15 @@ public final class Socket {
          - parameter bytes: An array of bytes to send.
     */
     public func send(_ bytes: [UInt8]) throws {
+        var totalBytesSent = 0
         let buffer = UnsafeBufferPointer<UInt8>(start: bytes, count: bytes.count)
-
-        let bytesSent = tls_write(currContext, buffer.baseAddress, bytes.count)
-
-        guard bytesSent >= 0 else {
-            throw TLSError.send(config.context.error)
+        
+        while totalBytesSent < bytes.count {
+            let bytesSent = tls_write(currContext, buffer.baseAddress?.advanced(by: totalBytesSent), bytes.count - totalBytesSent)
+            if bytesSent <= 0 {
+                throw TLSError.send(config.context.error)
+            }
+            totalBytesSent += bytesSent
         }
     }
 


### PR DESCRIPTION
tls_write() returns after writing a single message block if
SSL_MODE_ENABLE_PARTIAL_WRITE is enabled, which it is by default when
using tls_configure(). A message block is limited to 16384 bytes
(SSL3_RT_MAX_PLAIN_LENGTH). This patch changes send() to iterate over
the buffer until all data is sent.
