### PR TITLE
Add default configuration for system-provided cert store

### DIFF
--- a/Sources/TLS/Certificates.swift
+++ b/Sources/TLS/Certificates.swift
@@ -39,7 +39,7 @@ public enum Certificates {
     }
 
     public static var defaults: Certificates {
-        return .openbsd
+        return .system
     }
 }
 

--- a/Sources/TLS/Certificates.swift
+++ b/Sources/TLS/Certificates.swift
@@ -74,4 +74,18 @@ extension Certificates {
             )
         )
     }
+    
+    public static var system: Certificates {
+#if os(Linux)
+        let caCertFile = "/etc/ssl/certs/ca-certificates.crt"
+#else
+        let caCertFile = "/etc/ssl/cert.pem"
+#endif
+        
+        return .certificateAuthority(
+            signature: .signedFile(
+                caCertificateFile: caCertFile
+            )
+        )
+    }
 }

--- a/Sources/TLS/Certificates.swift
+++ b/Sources/TLS/Certificates.swift
@@ -39,7 +39,11 @@ public enum Certificates {
     }
 
     public static var defaults: Certificates {
-        return .system
+        if let system = system {
+            return system
+        } else {
+            return openbsd
+        }
     }
 }
 
@@ -75,7 +79,6 @@ extension Certificates {
         )
     }
     
-    public static var system: Certificates {
 #if os(Linux)
         let caCertFile = "/etc/ssl/certs/ca-certificates.crt"
 #else
@@ -85,6 +88,7 @@ extension Certificates {
         return .certificateAuthority(
             signature: .signedFile(
                 caCertificateFile: caCertFile
+    static var system: Certificates? {
             )
         )
     }

--- a/Tests/TLSTests/LiveTests.swift
+++ b/Tests/TLSTests/LiveTests.swift
@@ -94,7 +94,9 @@ class LiveTests: XCTestCase {
 
             XCTFail("Should not have connected.")
         } catch TLSError.connect(_) {
-
+            // on Linux, the TLS setup breaks
+        } catch TLSError.handshake(_) {
+            // on OSX, SNI throws a handshake error: "name 'nothttpbin.org' not present in server certificate"
         } catch {
             XCTFail("Wrong error: \(error).")
         }


### PR DESCRIPTION
The PR adds a new configuration to Certificates that loads `/etc/ssl/certs/ca-certificates.crt` on Ubuntu and `/etc/ssl/cert.pem` on OSX, which are the system-managed certificate stores on the respective platforms.

This has the following benefits:
- As the paths are now absolute, an application built with TLS will no longer be tightly coupled to the build path. This fixes outgoing HTTPS calls on Heroku without sacrificing certificate validation. (I tested this with a toy application manually.)
- (This is debatable, but) I think having a user-writable cert store is hard to reason about from a security perspective.

The second change also sets this as the default for the sake of new users, but can be reverted.