### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Swift wrapper for Transport Layer Security (TLS/SSL) using OpenSSL.
 
 ## 📖 Documentation
 
-Visit the Vapor web framework's [documentation](http://docs.vapor.codes) for instructions on how to use this package.
+Visit the Vapor web framework's [documentation](https://vapor.github.io/documentation/http/server.html#tls) for instructions on how to use this package.
 
 ## 💧 Community
 


### PR DESCRIPTION
The readme's link to documentation takes users to Vapor's doc homepage, but there isn't an immediate direction or source on how to get to the TLS docs. This commit adds that direct link.