### PR TITLE
Fails properly when system certificates can't be found

### DIFF
--- a/Sources/TLS/Certificates.swift
+++ b/Sources/TLS/Certificates.swift
@@ -41,25 +41,26 @@ public enum Certificates {
     }
 
     public static var defaults: Certificates {
-        if let system = system {
-            return system
-        } else {
-            return openbsd
-        }
+		if let system = system { return system }
+		if let openbsd = openbsd { return openbsd }
+		fatalError("No system certificates found")
     }
 }
 
 extension Certificates {
-    public static var openbsd: Certificates {
+    public static var openbsd: Certificates? {
         let root = #file.toCharacterSequence()
             .split(separator: "/", omittingEmptySubsequences: false)
             .dropLast(3)
             .map { String($0) }
             .joined(separator: "/")
+		
+		let filePath = root + "/Certs/openbsd_certs.pem"
+		guard fileExists(filePath) else { return nil }
 
         return .certificateAuthority(
             signature: .signedFile(
-                caCertificateFile: root + "/Certs/openbsd_certs.pem"
+                caCertificateFile: filePath
             )
         )
     }


### PR DESCRIPTION
The code right now assumes that system certificates on macOS will be in /etc/ssl, but this folder might not even exist, in which case the certificates should be loaded from the keychain. If you don't have that folder on your system, the code would take a second path where it would use certificates bundled with the code, which only works when you have the source code available. The code assumes these exists, through, and will fail with a very unhelpful "No such file or directory". This patch only changes the assumption that the bundled certificates will be there, and in case of failure will present the slight less unhelpful "Couldn't load system certificates".

There is still a failure case that I encountered where I have an empty /etc/ssl/certs directory, which will pass the check if the file exists, but will fail with the same "No such file or directory" error when actually used. This is not fixed in this patch.

Again, this only fixes the error message, not the actual problem that the certificates doesn't get loaded from the keychain when they aren't in /etc/ssl.